### PR TITLE
remove .decode('utf-8') for python3 support

### DIFF
--- a/ssh-audit.py
+++ b/ssh-audit.py
@@ -1651,7 +1651,7 @@ def audit(conf, sshv=None):
 	if err is None:
 		packet_type, payload = s.read_packet(sshv)
 		if packet_type < 0:
-			payload = str(payload).decode('utf-8')
+			payload = str(payload)
 			if payload == u'Protocol major versions differ.':
 				if sshv == 2 and conf.ssh1:
 					audit(conf, 1)


### PR DESCRIPTION
this PR intended to fix this issue #14 

As mentioned by @Rogdham, I think that we should removed `.decode('utf-8')` because ["Begin with Python 3, all string is unicode object."](http://stackoverflow.com/a/28584017), based recommendation from [answer for this question](http://stackoverflow.com/questions/26014209/python-3-4-str-attributeerror-str-object-has-no-attribute-decode) and [answer for this question](http://stackoverflow.com/questions/28583565/str-object-has-no-attribute-decode-python-3-error), it should be removed. 

note:
I've tested running the test `py.test --cov-report= --cov=ssh-audit -v test` and `python3 -m py.test --cov-report= --cov=ssh-audit -v test` for python3 and have no error.

But, double check should be done because I don't know what the reason behind of using `.decode('utf-8')`, maybe it to avoid strange behavior for special case (?).
