### PR TITLE
Replace getopt.getopt with getopt.gnu_getopt

### DIFF
--- a/ssh-audit.py
+++ b/ssh-audit.py
@@ -136,7 +136,7 @@ class AuditConf(object):
 			sopts = 'h1246p:bnvl:'
 			lopts = ['help', 'ssh1', 'ssh2', 'ipv4', 'ipv6', 'port',
 			         'batch', 'no-colors', 'verbose', 'level=']
-			opts, args = getopt.getopt(args, sopts, lopts)
+			opts, args = getopt.gnu_getopt(args, sopts, lopts)
 		except getopt.GetoptError as err:
 			usage_cb(str(err))
 		aconf.ssh1, aconf.ssh2 = False, False


### PR DESCRIPTION
Addresses Issue #41, gnu_getopt allows non-option arguments to be intermingled with option arguments whereas getopt stops processing arguments when a non option is found.